### PR TITLE
Fix date display setup...?

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -26,4 +26,4 @@ setup();
 
 // Customize the display of the dates within the site.
 require_once __DIR__ . '/inc/date-display.php';
-setup();
+Date_Display\setup();


### PR DESCRIPTION
Could it be that the last call to `setup` in the main plugin file should actually be `Date_Display\setup()`? 🙂