### PR TITLE
Make frontend properties filterable

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,6 +42,7 @@ module.exports = {
 	'rules': {
 		'@typescript-eslint/explicit-function-return-type': 'off',
 		'@typescript-eslint/indent': [ 'warn', 'tab' ],
+		'@typescript-eslint/no-param-reassign': 'error',
 		'@typescript-eslint/no-var-requires': 'off',
 		'@typescript-eslint/quotes': [ 'error', 'single' ],
 		'react/jsx-props-no-spreading': 'off',
@@ -71,7 +72,6 @@ module.exports = {
 			'ignoreComments': true,
 			'code': 200,
 		} ],
-		'no-param-reassign': 'error',
 		'indent': 'off',
 	},
 	'plugins': [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,7 +42,7 @@ module.exports = {
 	'rules': {
 		'@typescript-eslint/explicit-function-return-type': 'off',
 		'@typescript-eslint/indent': [ 'warn', 'tab' ],
-		'@typescript-eslint/no-param-reassign': 'error',
+		'@typescript-eslint/no-param-reassign': [ 'error', { 'props': true } ],
 		'@typescript-eslint/no-var-requires': 'off',
 		'@typescript-eslint/quotes': [ 'error', 'single' ],
 		'react/jsx-props-no-spreading': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,7 +42,6 @@ module.exports = {
 	'rules': {
 		'@typescript-eslint/explicit-function-return-type': 'off',
 		'@typescript-eslint/indent': [ 'warn', 'tab' ],
-		'@typescript-eslint/no-param-reassign': [ 'error', { 'props': true } ],
 		'@typescript-eslint/no-var-requires': 'off',
 		'@typescript-eslint/quotes': [ 'error', 'single' ],
 		'react/jsx-props-no-spreading': 'off',
@@ -72,6 +71,7 @@ module.exports = {
 			'ignoreComments': true,
 			'code': 200,
 		} ],
+		'no-param-reassign': [ 'error', { 'props': true } ],
 		'indent': 'off',
 	},
 	'plugins': [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -71,6 +71,7 @@ module.exports = {
 			'ignoreComments': true,
 			'code': 200,
 		} ],
+		'no-param-reassign': 'error',
 		'indent': 'off',
 	},
 	'plugins': [

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -6,6 +6,8 @@
 		<exclude name="HM.Files.FunctionFileName.WrongFile" />
 		<!-- This rule precludes verbosely documenting array parameters. -->
 		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop" />
+		<!-- We use / namespacing in our hooks. -->
+		<exclude name="WordPress.NamingConventions.ValidHookName.UseUnderscores" />
 	</rule>
 
 	<!-- Permit tests to omit function comments. -->

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 services:
   - docker
 
+branches:
+  only:
+    - main
+
 before_script:
   - travis_retry composer install --no-interaction --no-progress --prefer-source
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This is a WordPress plugin that provides an interface within the [block editor](
 
 The following filters are available to modify the behavior of this plugin.
 
-### `proposed_date_supported_post_types`
+### `proposed_date/supported_post_types`
 
-Modify which post types can take a proposed date.
+Server-side PHP filter to modify which post types can take a proposed date.
 
 Example: Add proposed date support for a custom post type, and remove it from core pages.
 
@@ -28,12 +28,12 @@ function filter_types_with_proposed_dates( array $post_types ) : array {
     $post_types[] = 'my_custom_post_type';
     return $post_types;
 }
-add_filter( 'proposed_date_supported_post_types', 'filter_types_with_proposed_dates', 10, 1 );
+add_filter( 'proposed_date/supported_post_types', 'filter_types_with_proposed_dates', 10, 1 );
 ```
 
-### `proposed_date_should_apply_proposal`
+### `proposed_date/should_accept_proposal`
 
-Determine, based on the old and new post status and the post object transitioning between those statuses, whether to check for a proposed date and apply it if found.
+Server-side PHP filter to determine, based on the old and new post status and the post object transitioning between those statuses, whether to check for a proposed date and apply it if found.
 
 Example: Accept proposed dates when transitioning to a custom status.
 
@@ -60,5 +60,11 @@ function accept_date_proposals_in_custom_status(
     }
     return $accept_proposal;
 }
-add_filter( 'proposed_date_should_accept_proposal', 'accept_date_proposals_in_custom_status', 10, 4 );
+add_filter( 'proposed_date/should_accept_proposal', 'accept_date_proposals_in_custom_status', 10, 4 );
+```
+
+Example: Always accept proposed dates when present, regardless of other circumstances.
+
+```php
+add_filter( 'proposed_date/should_accept_proposal', '__return_true' );
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a WordPress plugin that provides an interface within the [block editor](
 
 The following filters are available to modify the behavior of this plugin.
 
-### `proposed_date/supported_post_types`
+### `proposed_date/supported_post_types` (PHP filter)
 
 Server-side PHP filter to modify which post types can take a proposed date.
 
@@ -31,7 +31,7 @@ function filter_types_with_proposed_dates( array $post_types ) : array {
 add_filter( 'proposed_date/supported_post_types', 'filter_types_with_proposed_dates', 10, 1 );
 ```
 
-### `proposed_date/should_accept_proposal`
+### `proposed_date/should_accept_proposal` (PHP filter)
 
 Server-side PHP filter to determine, based on the old and new post status and the post object transitioning between those statuses, whether to check for a proposed date and apply it if found.
 
@@ -63,8 +63,48 @@ function accept_date_proposals_in_custom_status(
 add_filter( 'proposed_date/should_accept_proposal', 'accept_date_proposals_in_custom_status', 10, 4 );
 ```
 
-Example: Always accept proposed dates when present, regardless of other circumstances.
+Example: Always accept proposed dates when present, regardless of other circumstances. (If you do this you should also use the JS-side `proposed_date/date_label` filter to ensure you show the correct date value to contributors.)
 
 ```php
 add_filter( 'proposed_date/should_accept_proposal', '__return_true' );
+```
+
+### `proposed_date/date_label` (JS filter)
+
+Frontend JS filter to determine what date value to show when rendering the proposed date within Document sidebar.
+
+Example: Always show the proposed date, when present.
+
+```js
+function overrideProposedDateLabel( label, proposedDate, date ) {
+    if ( proposedDate ) {
+        return proposedDate;
+    }
+    return label;
+}
+wp.hooks.addFilter( 'proposed_date/date_label', 'my-plugin', overrideProposedDateLabel );
+```
+
+### `proposed_date/is_floating` (JS filter)
+
+Override whether to consider the post date is considered to be "floating" (that is to say, if the post is meant to be published "Immediately").
+
+Example: Force "floating" date status so that a proposed date will be displayed on the frontend even if an actual scheduled date value is present.
+
+```js
+function forceIsFloating( isFloating ) {
+    return true;
+}
+wp.hooks.addFilter( 'proposed_date/is_floating', 'my-plugin', forceIsFloating );
+```
+
+### `proposed_date/supported_statuses` (JS filter)
+
+Customize the list of post statuses which support a proposed date value.
+
+```js
+function filterSupportedStatuses( statuses ) {
+    return [ ...statuses, 'my_custom_status' ];
+}
+wp.hooks.addFilter( 'proposed_date/supported_statuses', 'my-plugin', filterSupportedStatuses );
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "kadamwhite/propose-draft-date",
+    "name": "humanmade/propose-draft-date",
     "type": "wordpress-plugin",
     "require-dev": {
         "10up/wp_mock": "0.4.2",

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -9,6 +9,9 @@ declare( strict_types=1 );
 
 namespace ProposeDraftDate;
 
+const ACCEPT_PROPOSAL_FILTER = 'proposed_date/should_accept_proposal';
+const SUPPORTED_POST_TYPES_FILTER = 'proposed_date/supported_post_types';
+
 /**
  * Connect namespace functions to actions & hooks.
  */
@@ -28,7 +31,7 @@ function get_supported_post_types() : array {
 	 *
 	 * @param array $post_types Array of post types supporting proposed dates. Defaults to "post" and "page".
 	 */
-	return apply_filters( 'proposed_date_supported_post_types', $default_post_types );
+	return apply_filters( 'proposed_date/supported_post_types', $default_post_types );
 }
 
 /**
@@ -103,7 +106,7 @@ function apply_proposed_date_before_insert( array $data, $postarr, $unsanitized_
 	 * @param string  $old_status      Previous post status.
 	 * @param WP_Post $post            The post being updated as it exists prior to the update.
 	 */
-	$accept_proposal = apply_filters( 'proposed_date_should_apply_proposal', $accept_proposal, $data['post_status'], $old_status, $existing_post );
+	$accept_proposal = apply_filters( ACCEPT_PROPOSAL_FILTER, $accept_proposal, $data['post_status'], $old_status, $existing_post );
 
 	if ( ! $accept_proposal ) {
 		return $data;

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -31,7 +31,7 @@ function get_supported_post_types() : array {
 	 *
 	 * @param array $post_types Array of post types supporting proposed dates. Defaults to "post" and "page".
 	 */
-	return apply_filters( 'proposed_date/supported_post_types', $default_post_types );
+	return apply_filters( SUPPORTED_POST_TYPES_FILTER, $default_post_types );
 }
 
 /**

--- a/plugin.php
+++ b/plugin.php
@@ -3,8 +3,8 @@
  * Plugin Name: Propose Draft Date
  * Description: Permit contributing authors to suggest a date for a draft post which takes effect on publish.
  * Version: 0.1
- * Author: K. Adam White
- * Author URI: https://www.kadamwhite.com
+ * Author: Human Made
+ * Author URI: https://www.humanmade.com
  * License:     GPL-2.0+
  */
 declare( strict_types=1 );

--- a/src/components/post-unscheduled-check/__snapshots__/post-unscheduled-check.test.tsx.snap
+++ b/src/components/post-unscheduled-check/__snapshots__/post-unscheduled-check.test.tsx.snap
@@ -1,6 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PostUnscheduledCheck returns children if all conditions are satisfied 1`] = `
+exports[`PostUnscheduledCheck returns children if all conditions are satisfied when post status is draft 1`] = `
+<div>
+  <p>
+    Wrapped Content
+  </p>
+</div>
+`;
+
+exports[`PostUnscheduledCheck returns children if all conditions are satisfied when post status is future 1`] = `
 <div>
   <p>
     Wrapped Content

--- a/src/components/post-unscheduled-check/__snapshots__/post-unscheduled-check.test.tsx.snap
+++ b/src/components/post-unscheduled-check/__snapshots__/post-unscheduled-check.test.tsx.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`PostUnscheduledCheck returns children if all conditions are satisfied when post status is auto-draft 1`] = `
+<div>
+  <p>
+    Wrapped Content
+  </p>
+</div>
+`;
+
 exports[`PostUnscheduledCheck returns children if all conditions are satisfied when post status is draft 1`] = `
 <div>
   <p>

--- a/src/components/post-unscheduled-check/index.tsx
+++ b/src/components/post-unscheduled-check/index.tsx
@@ -10,7 +10,7 @@ import { useSelect } from '@wordpress/data';
 import { applyFilters } from '@wordpress/hooks';
 
 export interface PostUnscheduledCheckProps {
-	isFloating: boolean,
+	isFloating: boolean;
 	postStatus: string;
 	hasPublishAction: boolean;
 	isPublished: boolean;

--- a/src/components/post-unscheduled-check/index.tsx
+++ b/src/components/post-unscheduled-check/index.tsx
@@ -24,13 +24,13 @@ export const PostUnscheduledCheck: FC<PostUnscheduledCheckProps> = ( {
 	isPublished,
 } ) => {
 	/**
-	 * Filters Floating Status of the post.
+	 * Permit overriding "floating date" status of the post with a filter.
 	 *
-	 * @param {Boolean} isFloating Default Floating.
+	 * @param {Boolean} isFloating Post's original Floating status.
 	 */
-	isFloating = applyFilters( 'proposed.date.unscheduled.is.floating', isFloating );
+	const filteredIsFloating = applyFilters( 'proposed_date/is_floating', isFloating );
 
-	if ( isPublished || hasPublishAction || ! isFloating ) {
+	if ( isPublished || hasPublishAction || ! filteredIsFloating ) {
 		return null;
 	}
 
@@ -39,7 +39,7 @@ export const PostUnscheduledCheck: FC<PostUnscheduledCheckProps> = ( {
 	 *
 	 * @param {String[]} statuses List of statuses supporting Proposed Date UI.
 	 */
-	const supportedStatuses = applyFilters( 'proposed.date.supported.statuses', [ 'auto-draft', 'draft', 'future' ] );
+	const supportedStatuses = applyFilters( 'proposed_date/supported_statuses', [ 'auto-draft', 'draft', 'future' ] );
 	if ( ! supportedStatuses.includes( postStatus ) ) {
 		return null;
 	}

--- a/src/components/post-unscheduled-check/index.tsx
+++ b/src/components/post-unscheduled-check/index.tsx
@@ -10,6 +10,7 @@ import { useSelect } from '@wordpress/data';
 import { applyFilters } from '@wordpress/hooks';
 
 export interface PostUnscheduledCheckProps {
+	isFloating: boolean,
 	postStatus: string;
 	hasPublishAction: boolean;
 	isPublished: boolean;
@@ -18,10 +19,18 @@ export interface PostUnscheduledCheckProps {
 export const PostUnscheduledCheck: FC<PostUnscheduledCheckProps> = ( {
 	children,
 	hasPublishAction,
+	isFloating,
 	postStatus,
 	isPublished,
 } ) => {
-	if ( isPublished || hasPublishAction ) {
+	/**
+	 * Filters Floating Status of the post.
+	 *
+	 * @param {Boolean} isFloating Default Floating.
+	 */
+	isFloating = applyFilters( 'proposed.date.unscheduled.is.floating', isFloating );
+
+	if ( isPublished || hasPublishAction || ! isFloating ) {
 		return null;
 	}
 
@@ -30,7 +39,7 @@ export const PostUnscheduledCheck: FC<PostUnscheduledCheckProps> = ( {
 	 *
 	 * @param {String[]} statuses List of statuses supporting Proposed Date UI.
 	 */
-	const supportedStatuses = applyFilters( 'proposed_date_supported_statuses', [ 'auto-draft', 'draft', 'future' ] );
+	const supportedStatuses = applyFilters( 'proposed.date.supported.statuses', [ 'auto-draft', 'draft', 'future' ] );
 	if ( ! supportedStatuses.includes( postStatus ) ) {
 		return null;
 	}
@@ -44,17 +53,19 @@ export const PostUnscheduledCheck: FC<PostUnscheduledCheckProps> = ( {
 
 /**
  * Wrapper component that will only render if the current user cannot schedule
- * posts or published.
+ * posts and the current post is not already scheduled or published.
  */
 const ConnectedPostUnscheduledCheck: FC = ( { children } ) => {
 	const props = useSelect( ( select ) => {
 		const {
 			getCurrentPost,
 			isCurrentPostPublished,
+			isEditedPostDateFloating,
 			getEditedPostAttribute,
 		} = select( 'core/editor' );
 		return {
 			hasPublishAction: Boolean( getCurrentPost()?._links?.['wp:action-publish'] ) || false,
+			isFloating: isEditedPostDateFloating(),
 			postStatus: getEditedPostAttribute( 'status' ),
 			isPublished: isCurrentPostPublished(),
 		};

--- a/src/components/post-unscheduled-check/index.tsx
+++ b/src/components/post-unscheduled-check/index.tsx
@@ -20,7 +20,7 @@ export const PostUnscheduledCheck: FC<PostUnscheduledCheckProps> = ( {
 	postStatus,
 	isPublished,
 } ) => {
-	if ( isPublished || hasPublishAction || ! [ 'draft', 'future' ].includes( postStatus ) ) {
+	if ( isPublished || hasPublishAction || ! [ 'auto-draft', 'draft', 'future' ].includes( postStatus ) ) {
 		return null;
 	}
 

--- a/src/components/post-unscheduled-check/index.tsx
+++ b/src/components/post-unscheduled-check/index.tsx
@@ -9,7 +9,7 @@ import React, { FC } from 'react';
 import { useSelect } from '@wordpress/data';
 
 export interface PostUnscheduledCheckProps {
-	isFloating: boolean;
+	postStatus: string;
 	hasPublishAction: boolean;
 	isPublished: boolean;
 }
@@ -17,10 +17,10 @@ export interface PostUnscheduledCheckProps {
 export const PostUnscheduledCheck: FC<PostUnscheduledCheckProps> = ( {
 	children,
 	hasPublishAction,
-	isFloating,
+	postStatus,
 	isPublished,
 } ) => {
-	if ( isPublished || hasPublishAction || ! isFloating ) {
+	if ( isPublished || hasPublishAction || ! [ 'draft', 'future' ].includes( postStatus ) ) {
 		return null;
 	}
 
@@ -33,18 +33,18 @@ export const PostUnscheduledCheck: FC<PostUnscheduledCheckProps> = ( {
 
 /**
  * Wrapper component that will only render if the current user cannot schedule
- * posts and the current post is not already scheduled or published.
+ * posts or published.
  */
 const ConnectedPostUnscheduledCheck: FC = ( { children } ) => {
 	const props = useSelect( ( select ) => {
 		const {
 			getCurrentPost,
 			isCurrentPostPublished,
-			isEditedPostDateFloating,
+			getEditedPostAttribute,
 		} = select( 'core/editor' );
 		return {
 			hasPublishAction: Boolean( getCurrentPost()?._links?.['wp:action-publish'] ) || false,
-			isFloating: isEditedPostDateFloating(),
+			postStatus: getEditedPostAttribute( 'status' ),
 			isPublished: isCurrentPostPublished(),
 		};
 	} );

--- a/src/components/post-unscheduled-check/post-unscheduled-check.test.tsx
+++ b/src/components/post-unscheduled-check/post-unscheduled-check.test.tsx
@@ -26,8 +26,20 @@ describe( 'PostUnscheduledCheck', () => {
 
 	afterEach( cleanup );
 
+	it( 'returns null if a post does not have a "floating" date', () => {
+		const { container, queryByText } = renderWithProps( {
+			isFloating: false,
+			postStatus: 'draft',
+			hasPublishAction: false,
+			isPublished: false,
+		} );
+		expect( container ).toMatchInlineSnapshot( '<div />' );
+		expect( queryByText( 'Wrapped Content' ) ).toBeNull();
+	} );
+
 	it( 'returns null if a post is not draft', () => {
 		const { container, queryByText } = renderWithProps( {
+			isFloating: true,
 			postStatus: 'not-draft',
 			hasPublishAction: false,
 			isPublished: false,
@@ -38,6 +50,7 @@ describe( 'PostUnscheduledCheck', () => {
 
 	it( 'returns null if the user is capable of publishing posts', () => {
 		const { container, queryByText } = renderWithProps( {
+			isFloating: true,
 			postStatus: 'draft',
 			hasPublishAction: true,
 			isPublished: false,
@@ -48,6 +61,7 @@ describe( 'PostUnscheduledCheck', () => {
 
 	it( 'returns null if isPublished is true', () => {
 		const { container, queryByText } = renderWithProps( {
+			isFloating: true,
 			postStatus: 'draft',
 			hasPublishAction: false,
 			isPublished: true,
@@ -58,6 +72,7 @@ describe( 'PostUnscheduledCheck', () => {
 
 	it( 'returns children if all conditions are satisfied when post status is auto-draft', () => {
 		const { container, queryByText } = renderWithProps( {
+			isFloating: true,
 			postStatus: 'auto-draft',
 			hasPublishAction: false,
 			isPublished: false,
@@ -68,6 +83,7 @@ describe( 'PostUnscheduledCheck', () => {
 
 	it( 'returns children if all conditions are satisfied when post status is draft', () => {
 		const { container, queryByText } = renderWithProps( {
+			isFloating: true,
 			postStatus: 'draft',
 			hasPublishAction: false,
 			isPublished: false,
@@ -78,6 +94,7 @@ describe( 'PostUnscheduledCheck', () => {
 
 	it( 'returns children if all conditions are satisfied when post status is future', () => {
 		const { container, queryByText } = renderWithProps( {
+			isFloating: true,
 			postStatus: 'future',
 			hasPublishAction: false,
 			isPublished: false,

--- a/src/components/post-unscheduled-check/post-unscheduled-check.test.tsx
+++ b/src/components/post-unscheduled-check/post-unscheduled-check.test.tsx
@@ -56,6 +56,16 @@ describe( 'PostUnscheduledCheck', () => {
 		expect( queryByText( 'Wrapped Content' ) ).toBeNull();
 	} );
 
+	it( 'returns children if all conditions are satisfied when post status is auto-draft', () => {
+		const { container, queryByText } = renderWithProps( {
+			postStatus: 'auto-draft',
+			hasPublishAction: false,
+			isPublished: false,
+		} );
+		expect( container ).toMatchSnapshot();
+		expect( queryByText( 'Wrapped Content' ) ).toBeInTheDocument();
+	} );
+
 	it( 'returns children if all conditions are satisfied when post status is draft', () => {
 		const { container, queryByText } = renderWithProps( {
 			postStatus: 'draft',

--- a/src/components/post-unscheduled-check/post-unscheduled-check.test.tsx
+++ b/src/components/post-unscheduled-check/post-unscheduled-check.test.tsx
@@ -26,9 +26,9 @@ describe( 'PostUnscheduledCheck', () => {
 
 	afterEach( cleanup );
 
-	it( 'returns null if a post doe not have a "floating" date', () => {
+	it( 'returns null if a post is not draft', () => {
 		const { container, queryByText } = renderWithProps( {
-			isFloating: false,
+			postStatus: 'not-draft',
 			hasPublishAction: false,
 			isPublished: false,
 		} );
@@ -38,7 +38,7 @@ describe( 'PostUnscheduledCheck', () => {
 
 	it( 'returns null if the user is capable of publishing posts', () => {
 		const { container, queryByText } = renderWithProps( {
-			isFloating: true,
+			postStatus: 'draft',
 			hasPublishAction: true,
 			isPublished: false,
 		} );
@@ -48,7 +48,7 @@ describe( 'PostUnscheduledCheck', () => {
 
 	it( 'returns null if isPublished is true', () => {
 		const { container, queryByText } = renderWithProps( {
-			isFloating: true,
+			postStatus: 'draft',
 			hasPublishAction: false,
 			isPublished: true,
 		} );
@@ -56,9 +56,19 @@ describe( 'PostUnscheduledCheck', () => {
 		expect( queryByText( 'Wrapped Content' ) ).toBeNull();
 	} );
 
-	it( 'returns children if all conditions are satisfied', () => {
+	it( 'returns children if all conditions are satisfied when post status is draft', () => {
 		const { container, queryByText } = renderWithProps( {
-			isFloating: true,
+			postStatus: 'draft',
+			hasPublishAction: false,
+			isPublished: false,
+		} );
+		expect( container ).toMatchSnapshot();
+		expect( queryByText( 'Wrapped Content' ) ).toBeInTheDocument();
+	} );
+
+	it( 'returns children if all conditions are satisfied when post status is future', () => {
+		const { container, queryByText } = renderWithProps( {
+			postStatus: 'future',
 			hasPublishAction: false,
 			isPublished: false,
 		} );

--- a/src/components/post-unscheduled-check/post-unscheduled-check.test.tsx
+++ b/src/components/post-unscheduled-check/post-unscheduled-check.test.tsx
@@ -37,7 +37,7 @@ describe( 'PostUnscheduledCheck', () => {
 		expect( queryByText( 'Wrapped Content' ) ).toBeNull();
 	} );
 
-	it( 'returns null if a post is not draft', () => {
+	it( 'returns null if a post does not have a supported status', () => {
 		const { container, queryByText } = renderWithProps( {
 			isFloating: true,
 			postStatus: 'not-draft',

--- a/src/components/proposed-date-form/index.tsx
+++ b/src/components/proposed-date-form/index.tsx
@@ -68,7 +68,7 @@ const PostScheduleWrapper: FC = ( { children } ) => {
 	} ) );
 
 	let date = useSelect( ( select ) => select( 'core/editor' ).getEditedPostAttribute( 'date' ) );
-	date = proposedDate && proposedDate;
+	date = proposedDate.length > 0 ? proposedDate : date;
 
 	return (
 		<PostSchedule

--- a/src/components/proposed-date-form/index.tsx
+++ b/src/components/proposed-date-form/index.tsx
@@ -7,6 +7,7 @@ import React, { FC, useCallback } from 'react';
  * WordPress dependencies.
  */
 import { DateTimePicker } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies.
@@ -66,9 +67,12 @@ const PostScheduleWrapper: FC = ( { children } ) => {
 		),
 	} ) );
 
+	let date = useSelect( ( select ) => select( 'core/editor' ).getEditedPostAttribute( 'date' ) );
+	date = proposedDate && proposedDate;
+
 	return (
 		<PostSchedule
-			date={ proposedDate }
+			date={ date }
 			is12HourTime={ is12HourTime }
 			onChangeDate={ updateProposedDate }
 		>

--- a/src/components/proposed-date-label/index.tsx
+++ b/src/components/proposed-date-label/index.tsx
@@ -21,19 +21,23 @@ import useMeta from '../../hooks/use-meta';
  */
 export const ProposedDateLabel: FC<{
 	date?: string;
-	isFloating: boolean;
+	postStatus: string;
 	proposedDate?: string;
-}> = ( { date, isFloating, proposedDate } ) => {
+}> = ( { date, postStatus, proposedDate } ) => {
 	const { dateFormat } = useExperimentalSettings( ( settings ) => ( {
 		dateFormat: `${ settings.formats.date } ${ settings.formats.time }`,
 	} ) );
 
-	if ( date && ! isFloating ) {
-		return dateI18n( dateFormat, date );
+	if ( postStatus !== 'draft' ) {
+		return __( 'Immediately' );
 	}
 
-	if ( isFloating && proposedDate ) {
+	if ( proposedDate ) {
 		return dateI18n( dateFormat, proposedDate );
+	}
+
+	if ( date ) {
+		return dateI18n( dateFormat, date );
 	}
 
 	return __( 'Immediately' );
@@ -45,15 +49,15 @@ export const ProposedDateLabel: FC<{
  */
 export default function<FC> () {
 	const [ proposedDate ] = useMeta<string>( 'proposed_publish_date' );
-	const { date, isFloating } = useSelect( ( select ) => ( {
+	const { date, postStatus } = useSelect( ( select ) => ( {
 		date: select( 'core/editor' ).getEditedPostAttribute( 'date' ),
-		isFloating: select( 'core/editor' ).isEditedPostDateFloating(),
+		postStatus: select( 'core/editor' ).getEditedPostAttribute( 'status' ),
 	} ) );
 
 	return (
 		<ProposedDateLabel
 			date={ date }
-			isFloating={ isFloating }
+			postStatus={ postStatus }
 			proposedDate={ proposedDate }
 		/>
 	);

--- a/src/components/proposed-date-label/index.tsx
+++ b/src/components/proposed-date-label/index.tsx
@@ -21,16 +21,11 @@ import useMeta from '../../hooks/use-meta';
  */
 export const ProposedDateLabel: FC<{
 	date?: string;
-	postStatus: string;
 	proposedDate?: string;
-}> = ( { date, postStatus, proposedDate } ) => {
+}> = ( { date, proposedDate } ) => {
 	const { dateFormat } = useExperimentalSettings( ( settings ) => ( {
 		dateFormat: `${ settings.formats.date } ${ settings.formats.time }`,
 	} ) );
-
-	if ( postStatus !== 'draft' ) {
-		return __( 'Immediately' );
-	}
 
 	if ( proposedDate ) {
 		return dateI18n( dateFormat, proposedDate );
@@ -50,14 +45,12 @@ export const ProposedDateLabel: FC<{
 export default function<FC> () {
 	const [ proposedDate ] = useMeta<string>( 'proposed_publish_date' );
 	const { date, postStatus } = useSelect( ( select ) => ( {
-		date: select( 'core/editor' ).getEditedPostAttribute( 'date' ),
-		postStatus: select( 'core/editor' ).getEditedPostAttribute( 'status' ),
+		date: select( 'core/editor' ).getEditedPostAttribute( 'date' )
 	} ) );
 
 	return (
 		<ProposedDateLabel
 			date={ date }
-			postStatus={ postStatus }
 			proposedDate={ proposedDate }
 		/>
 	);

--- a/src/components/proposed-date-label/index.tsx
+++ b/src/components/proposed-date-label/index.tsx
@@ -9,6 +9,7 @@ import React, { FC } from 'react';
 import { __ } from '@wordpress/i18n';
 import { dateI18n } from '@wordpress/date';
 import { useSelect } from '@wordpress/data';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies.
@@ -22,20 +23,29 @@ import useMeta from '../../hooks/use-meta';
 export const ProposedDateLabel: FC<{
 	date?: string;
 	proposedDate?: string;
-}> = ( { date, proposedDate } ) => {
+	isFloating: boolean;
+}> = ( { date, proposedDate, isFloating } ) => {
+	/**
+	 * Filters Floating Status of the post.
+	 *
+	 * @param {Boolean} isFloating Default Floating.
+	 */
+	isFloating = applyFilters( 'proposed.date.label.is.floating', isFloating );
+
 	const { dateFormat } = useExperimentalSettings( ( settings ) => ( {
 		dateFormat: `${ settings.formats.date } ${ settings.formats.time }`,
 	} ) );
+	const defaultLabel = __( 'Immediately' );
+	const dateLabel = isFloating
+		? ( proposedDate ? dateI18n( dateFormat, proposedDate ) : defaultLabel )
+		: ( date ? dateI18n( dateFormat, date ) : defaultLabel );
 
-	if ( proposedDate ) {
-		return dateI18n( dateFormat, proposedDate );
-	}
-
-	if ( date ) {
-		return dateI18n( dateFormat, date );
-	}
-
-	return __( 'Immediately' );
+	/**
+	 * Filters Label for proposed Draft label.
+	 *
+	 * @param {String} dateLabel Proposed Date Label or string `Immediately`.
+	 */
+	return applyFilters( 'proposed.date.label.date.label', dateLabel );
 };
 
 /**
@@ -44,14 +54,16 @@ export const ProposedDateLabel: FC<{
  */
 export default function<FC> () {
 	const [ proposedDate ] = useMeta<string>( 'proposed_publish_date' );
-	const { date, postStatus } = useSelect( ( select ) => ( {
-		date: select( 'core/editor' ).getEditedPostAttribute( 'date' )
+	const { date, isFloating } = useSelect( ( select ) => ( {
+		date: select( 'core/editor' ).getEditedPostAttribute( 'date' ),
+		isFloating: select( 'core/editor').isEditedPostDateFloating(),
 	} ) );
 
 	return (
 		<ProposedDateLabel
 			date={ date }
 			proposedDate={ proposedDate }
+			isFloating={ isFloating }
 		/>
 	);
 }

--- a/src/components/proposed-date-label/index.tsx
+++ b/src/components/proposed-date-label/index.tsx
@@ -56,7 +56,7 @@ export default function<FC> () {
 	const [ proposedDate ] = useMeta<string>( 'proposed_publish_date' );
 	const { date, isFloating } = useSelect( ( select ) => ( {
 		date: select( 'core/editor' ).getEditedPostAttribute( 'date' ),
-		isFloating: select( 'core/editor').isEditedPostDateFloating(),
+		isFloating: select( 'core/editor' ).isEditedPostDateFloating(),
 	} ) );
 
 	return (

--- a/src/components/proposed-date-label/index.tsx
+++ b/src/components/proposed-date-label/index.tsx
@@ -46,9 +46,11 @@ export const ProposedDateLabel: FC<{
 	/**
 	 * Filters the text which displays the proposed date in the Document sidebar.
 	 *
-	 * @param {String} dateLabel The string to display when showing the date.
+	 * @param {String} dateLabel    The string to display when showing the date.
+	 * @param {String} proposedDate Proposed date meta value, if present.
+	 * @param {String} date         Current post date.
 	 */
-	return applyFilters( 'proposed_date/date_label', dateLabel );
+	return applyFilters( 'proposed_date/date_label', dateLabel, proposedDate, date );
 };
 
 /**

--- a/src/components/proposed-date-label/index.tsx
+++ b/src/components/proposed-date-label/index.tsx
@@ -26,26 +26,29 @@ export const ProposedDateLabel: FC<{
 	isFloating: boolean;
 }> = ( { date, proposedDate, isFloating } ) => {
 	/**
-	 * Filters Floating Status of the post.
+	 * Permit overriding "floating date" status of the post with a filter.
 	 *
-	 * @param {Boolean} isFloating Default Floating.
+	 * @param {Boolean} isFloating Post's original Floating status.
 	 */
-	isFloating = applyFilters( 'proposed.date.label.is.floating', isFloating );
+	const filteredIsFloating = applyFilters( 'proposed_date/is_floating', isFloating );
 
 	const { dateFormat } = useExperimentalSettings( ( settings ) => ( {
 		dateFormat: `${ settings.formats.date } ${ settings.formats.time }`,
 	} ) );
-	const defaultLabel = __( 'Immediately' );
-	const dateLabel = isFloating
-		? ( proposedDate ? dateI18n( dateFormat, proposedDate ) : defaultLabel )
-		: ( date ? dateI18n( dateFormat, date ) : defaultLabel );
+
+	let dateLabel = __( 'Immediately' );
+	if ( date && ! filteredIsFloating ) {
+		dateLabel = dateI18n( dateFormat, date );
+	} else if ( filteredIsFloating && proposedDate ) {
+		dateLabel = dateI18n( dateFormat, proposedDate );
+	}
 
 	/**
-	 * Filters Label for proposed Draft label.
+	 * Filters the text which displays the proposed date in the Document sidebar.
 	 *
-	 * @param {String} dateLabel Proposed Date Label or string `Immediately`.
+	 * @param {String} dateLabel The string to display when showing the date.
 	 */
-	return applyFilters( 'proposed.date.label.date.label', dateLabel );
+	return applyFilters( 'proposed_date/date_label', dateLabel );
 };
 
 /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,6 +17,7 @@ require '/wp-phpunit/includes/functions.php';
 
 // Load in our custom files.
 require $base_dir . '/inc/meta.php';
+require $base_dir . '/inc/namespace.php';
 
 // Start up the WP testing environment.
 require '/wp-phpunit/includes/bootstrap.php';

--- a/tests/inc/class-test-filters.php
+++ b/tests/inc/class-test-filters.php
@@ -45,14 +45,23 @@ class Test_Filters extends WP_UnitTestCase {
 	 */
 	public function data_get_supported_post_types() : array {
 		return [
-			[ [ 'post', 'page' ], null ],
-			[ [ 'post', 'page', 'my_cpt' ], function( $supported_types ) {
-				$supported_types[] = 'my_cpt';
-				return $supported_types;
-			} ],
-			[ [ 'custom', 'types', 'only!' ], function( $supported_types ) {
-				return [ 'custom', 'types', 'only!' ];
-			} ],
+			[
+				[ 'post', 'page' ],
+				null,
+			],
+			[
+				[ 'post', 'page', 'my_cpt' ],
+				function( $supported_types ) {
+					$supported_types[] = 'my_cpt';
+					return $supported_types;
+				},
+			],
+			[
+				[ 'custom', 'types', 'only!' ],
+				function( $supported_types ) {
+					return [ 'custom', 'types', 'only!' ];
+				},
+			],
 		];
 	}
 }

--- a/tests/inc/class-test-filters.php
+++ b/tests/inc/class-test-filters.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Validate that key actions are correctly filterable.
+ *
+ * @package propose-draft-date
+ */
+
+declare( strict_types=1 );
+
+namespace ProposeDraftDate\Tests\Filters;
+
+use ProposeDraftDate;
+use WP_UnitTestCase;
+
+/**
+ * Test the Meta namespace.
+ */
+class Test_Filters extends WP_UnitTestCase {
+	/**
+	 * Validate the filterability of the supported post types list.
+	 *
+	 * @dataProvider data_get_supported_post_types
+	 *
+	 * @param string[]      $expected        The expected resulting array of post types.
+	 * @param callable|null $filter_function Function to filter supported types, or null.
+	 * @return void
+	 */
+	public function test_get_supported_post_types( array $expected, ?callable $filter_function ) : void {
+		if ( is_callable( $filter_function ) ) {
+			add_filter( 'proposed_date/supported_post_types', $filter_function );
+		}
+
+		$this->assertEquals( $expected, ProposeDraftDate\get_supported_post_types() );
+	}
+
+	/**
+	 * Data provider for test_get_supported_post_types.
+	 *
+	 * @return array {
+	 *     @type array {
+	 *         @type string[]  $expected        The expected resulting array of post types.
+	 *         @type ?callable $filter_function Function to filter supported types, or null.
+	 *     }
+	 * }
+	 */
+	public function data_get_supported_post_types() : array {
+		return [
+			[ [ 'post', 'page' ], null ],
+			[ [ 'post', 'page', 'my_cpt' ], function( $supported_types ) {
+				$supported_types[] = 'my_cpt';
+				return $supported_types;
+			} ],
+			[ [ 'custom', 'types', 'only!' ], function( $supported_types ) {
+				return [ 'custom', 'types', 'only!' ];
+			} ],
+		];
+	}
+}


### PR DESCRIPTION
- Make frontend UI components aware of post status, and hide proposed date UI for unsupported post statuses
- Permit list of supported post statuses to be filtered using `wp.hooks.addFilter`
- Allow post "floating" status to be filtered using `wp.hooks.addFilter`
- Allow post date label (e.g. date, proposed date, or "Immediately") to be filtered using `wp.hooks.addFilter`
- Namespace standardize hook names throughout application
