### PR TITLE
Make status list filterable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3935,9 +3935,9 @@
       }
     },
     "@wordpress/hooks": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.8.0.tgz",
-      "integrity": "sha512-5FbiVz6T2Frw45NmPDF9GbAFU8iQy64YSZaM+61tUngB+Uzdv0A4pA8C8WIDPlw16QJXseZ4uLce4U9HlJQ3dw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.9.0.tgz",
+      "integrity": "sha512-RL7bIIwy1BJWPOicwtDdC1cO+0HqHhnRtry8qeatv+/qN7O5YrJaslCMot7R4Y9cIgzX8C8Vj2BN2QsXLqUAGg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.9.2"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@wordpress/data": "^4.19.0",
     "@wordpress/date": "^3.9.0",
     "@wordpress/edit-post": "^3.18.0",
+    "@wordpress/hooks": "^2.9.0",
     "@wordpress/i18n": "^3.13.0",
     "@wordpress/jest-preset-default": "^6.1.0",
     "block-editor-hmr": "^0.6.0",

--- a/src/components/post-unscheduled-check/index.tsx
+++ b/src/components/post-unscheduled-check/index.tsx
@@ -7,6 +7,7 @@ import React, { FC } from 'react';
  * WordPress dependencies.
  */
 import { useSelect } from '@wordpress/data';
+import { applyFilters } from '@wordpress/hooks';
 
 export interface PostUnscheduledCheckProps {
 	postStatus: string;
@@ -20,7 +21,17 @@ export const PostUnscheduledCheck: FC<PostUnscheduledCheckProps> = ( {
 	postStatus,
 	isPublished,
 } ) => {
-	if ( isPublished || hasPublishAction || ! [ 'auto-draft', 'draft', 'future' ].includes( postStatus ) ) {
+	if ( isPublished || hasPublishAction ) {
+		return null;
+	}
+
+	/**
+	 * Filter whether the proposed date UI should be shown for a given post status.
+	 *
+	 * @param {String[]} statuses List of statuses supporting Proposed Date UI.
+	 */
+	const supportedStatuses = applyFilters( 'proposed_date_supported_statuses', [ 'auto-draft', 'draft', 'future' ] );
+	if ( ! supportedStatuses.includes( postStatus ) ) {
 		return null;
 	}
 


### PR DESCRIPTION
This PR merges `main` into `get-correct-time` (to reduce package conflicts), then adds a commit to use the WP Hooks package to make the status list filterable. It should be regarded as pseudo-code because I have not yet validated that this works as expected, nor updated tests