### PR TITLE
Prevent unexpected error when proposedDate is undefined.

### DIFF
--- a/src/components/proposed-date-form/index.tsx
+++ b/src/components/proposed-date-form/index.tsx
@@ -68,7 +68,7 @@ const PostScheduleWrapper: FC = ( { children } ) => {
 	} ) );
 
 	let date = useSelect( ( select ) => select( 'core/editor' ).getEditedPostAttribute( 'date' ) );
-	date = proposedDate.length > 0 ? proposedDate : date;
+	date = proposedDate?.length > 0 ? proposedDate : date;
 
 	return (
 		<PostSchedule


### PR DESCRIPTION
Related issue #62 

This PR fixes an unexpected error when `proposedDate` is undefined.

I have used `Optional chaining (?.)` to prevent the issue from being caused, more can be [read on it here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) :
> The optional chaining (?.) operator accesses an object's property or calls a function. If the object is [undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined) or [null](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/null), it returns [undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined) instead of throwing an error.